### PR TITLE
Fix properties

### DIFF
--- a/src/SmartEmailing.php
+++ b/src/SmartEmailing.php
@@ -217,7 +217,7 @@ class SmartEmailing
 
 		if (is_array($properties)) {
 			foreach ($properties as $name => $value) {
-				$contact['data'][$name] = $value;
+				$contact[$name] = $value;
 			}
 		}
 


### PR DESCRIPTION
Delete data key, because properties must be in root of contact key

```
array (1)
    data => array (1)
        0 => array (2)
            emailaddress => "mail@example.com" (21)
            data => array (1) [ ... ]
```
vs
```
array (1)
    data => array (1)
        0 => array (2)
            emailaddress => "mail@example.com" (21)
            blacklisted => 1
```

for `$this->smartEmailing->importContact($email, null, ['blacklisted' => 1]);`